### PR TITLE
Fix for windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,10 @@ __pycache__/
 # C extensions
 *.so
 
+# editor project config
+# pycharm
+.idea
+
 # Distribution / packaging
 .Python
 env/

--- a/.gitignore
+++ b/.gitignore
@@ -48,6 +48,7 @@ nosetests.xml
 coverage.xml
 *,cover
 .hypothesis/
+.pytest_cache/
 
 # Translations
 *.mo

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -10,4 +10,4 @@ Development Lead
 Contributors
 ------------
 
-None yet. Why not be the first?
+* Sebastian Weigand <s.weigand.phy@gmail.com>

--- a/pytest_localftpserver/plugin.py
+++ b/pytest_localftpserver/plugin.py
@@ -90,7 +90,11 @@ class MPFTPServer(threading.Thread):
         if hasattr(self._server, "_ftp_home"):
             return self._server._ftp_home
         else:
-            return self._server._anon_root
+            return None
+
+    @property
+    def anon_root(self):
+        return self._server._anon_root
 
     def stop(self):
         self._server.stop()

--- a/pytest_localftpserver/plugin.py
+++ b/pytest_localftpserver/plugin.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
 
-import multiprocessing
 import os
 import shutil
 import socket
 import tempfile
+import threading
 
 
 from pyftpdlib.authorizers import DummyAuthorizer
@@ -68,7 +68,7 @@ class SimpleFTPServer(FTPServer):
                 shutil.rmtree(self._anon_root, ignore_errors=True)
 
 
-class MPFTPServer(multiprocessing.Process):
+class MPFTPServer(threading.Thread):
 
     def __init__(self, username, password, ftp_home, ftp_port, **kwargs):
 
@@ -94,7 +94,9 @@ class MPFTPServer(multiprocessing.Process):
 
     def stop(self):
         self._server.stop()
-        self.terminate()
+
+    def __del__(self):
+        self.stop()
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,6 +1,8 @@
 pip>=8.1.2
+bumpversion>=0.5.3
 wheel>=0.30.0
-flake8==2.6.0
+watchdog>=0.8.3
+flake8>=2.6.0
 tox>=2.3.1
 coverage>=4.1
 Sphinx>=1.4.8

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,4 @@
+import os
+import sys
+MODULE_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+sys.path.insert(0, MODULE_PATH)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,4 +1,0 @@
-import os
-import sys
-MODULE_PATH = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
-sys.path.insert(0, MODULE_PATH)

--- a/tests/test_pytest_localftpserver.py
+++ b/tests/test_pytest_localftpserver.py
@@ -17,7 +17,8 @@ from ftplib import FTP
 
 import pytest
 
-from pytest_localftpserver import plugin
+# from pytest_localftpserver import plugin
+from pytest_localftpserver.plugin import ftpserver, MPFTPServer
 
 
 if sys.version_info[0] == 3:
@@ -27,7 +28,7 @@ else:
 
 
 def test_ftpserver(ftpserver):
-    assert isinstance(ftpserver, plugin.MPFTPServer)
+    assert isinstance(ftpserver, MPFTPServer)
 
 
 def test_file_upload(ftpserver):

--- a/tests/test_pytest_localftpserver.py
+++ b/tests/test_pytest_localftpserver.py
@@ -17,8 +17,7 @@ from ftplib import FTP
 
 import pytest
 
-# from pytest_localftpserver import plugin
-from pytest_localftpserver.plugin import ftpserver, MPFTPServer
+from pytest_localftpserver import plugin
 
 
 if sys.version_info[0] == 3:
@@ -28,7 +27,7 @@ else:
 
 
 def test_ftpserver(ftpserver):
-    assert isinstance(ftpserver, MPFTPServer)
+    assert isinstance(ftpserver, plugin.MPFTPServer)
 
 
 def test_file_upload(ftpserver):

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,5 @@
 [tox]
-envlist = py{27,34,35,36}
-
-[travis]
-os =
-  linux: py{27,34,35,36},flake8
-  osx: py{27,34,35,36}
+envlist = py27, py33, py34, py35, flake8
 
 [testenv:flake8]
 basepython=python
@@ -12,5 +7,16 @@ deps=flake8
 commands=flake8 pytest_localftpserver
 
 [testenv]
-deps = -r{toxinidir}/requirements_dev.txt
-commands = py.test --basetemp={envtmpdir}
+setenv =
+    PYTHONPATH = {toxinidir}:{toxinidir}/pytest_localftpserver
+deps =
+    -r{toxinidir}/requirements_dev.txt
+commands =
+    pip install -U pip
+    py.test --basetemp={envtmpdir}
+
+
+; If you want to make tox run the tests with the same versions, create a
+; requirements.txt with the pinned versions and uncomment the following lines:
+; deps =
+;     -r{toxinidir}/requirements.txt

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py33, py34, py35, flake8
+envlist = py27, py34, py35, py36, flake8
 
 [testenv:flake8]
 basepython=python

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py34, py35, py36, flake8
+envlist = py26, py27, py33, py34, py35, flake8
 
 [testenv:flake8]
 basepython=python


### PR DESCRIPTION
Hi there, 

I wanted to use your package to test my code and discovered that it isn't working on windows.
When I started working on it, I discovered that it doesn't pass the tox testsuite on Linux, so I began fixing that as well.
Since I made quite some changes I want to explain why I did what.

1. Fixing the problem with Windows:
Apparently the problem with Windows was, that the socket couldn't be pickled. Changing MPFTPServer from being a subclass of `multiprocessing.Process` to a subclass  of `threading.Thread` fixed that Problem.

2. Fixing the tests:
Since `SimpleFTPServer` does create the home dir for users and anno as a temp folder with random location and starts the Server at a free random port, there is no point in testing for the actual location and port since they change each time (`test_ftpserver`).
Due to the different errors Python 2 and Python3 raise, I differentiated between those in `test_ftp_stopped`. Also, I changed `ConnectionRefusedError` to `OSError`, which is a superclass of `ConnectionRefusedError` and appears to be more robust (it caused a test to fail, but I forgot which one).

3. Cleaning up plugin.py :

- `MPFTPServer`:
Since `self.username`, `self.password`, `self.server_home` and `self.server_port` were only used to initialize `SimpleFTPServer` I dropped those properties.  Also, I initialized `SimpleFTPServer` in the `__init__` part and not in `run` since it caused a test to fail (forgot AGAIN which one). For compatibility and a cleaner interface I reimplemented `server_home` and `server_port`, which now return the correct path and port. Added `anon_root` as it was before `Fixes for Mac OS X`.

- `ftpserver`:
Since `MPFTPServer` is defined in the same file I didn't see a need to import it from itself.

4. Dropping support for Python 2.6 and 3.3:
Since Travis also dropped its support as did quite some other projects i thought it would be a good idea to do so aswell (when i have time I'll try to make the tests work on travis).

All in all now it works and passes  the tests on Ubuntu 16.04 and on Windows10.
@JonathanHerrmann Maybe you could check if it passes the tests on OSX.

Best regards and I hope for your feedback on my changes
Sebastian


  