### PR TITLE
Add continuous integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,74 @@
+sudo: false
+language: python
+cache: pip
+
+python:
+  - 2.7
+  - 3.4
+  - 3.5
+  - 3.6
+
+matrix:
+  fast_finish: true
+  include:
+    - python: 3.6
+      env: TOXENV=flake8
+    - language: generic
+      python: 2.7
+      os: osx
+      before_install:     
+        - wget https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh;
+        - bash miniconda.sh -b -p $HOME/miniconda
+        - export PATH="$HOME/miniconda/bin:$PATH"
+        - conda create -n py27 python=2.7 -y
+      install:
+        - source activate py27
+        - pip install tox
+        - conda install -y --name py27 virtualenv
+      script: tox -e py27
+      
+    - language: generic
+      python: 3.4
+      os: osx
+      before_install:
+        - wget https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh;
+        - bash miniconda.sh -b -p $HOME/miniconda
+        - export PATH="$HOME/miniconda/bin:$PATH"
+        - conda create -n py34 python=3.4 -y
+      install:
+        - source activate py34
+        - pip install tox
+        - conda install -y --name py34 virtualenv
+      script: tox -e py34
+      
+    - language: generic
+      python: 3.5
+      os: osx
+      before_install:
+        - wget https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh;
+        - bash miniconda.sh -b -p $HOME/miniconda
+        - export PATH="$HOME/miniconda/bin:$PATH"
+        - conda create -n py35 python=3.5 -y
+      install:
+        - source activate py35
+        - pip install tox
+        - conda install -y --name py35 virtualenv
+      script: tox -e py35
+      
+    - language: generic
+      python: 3.6
+      os: osx
+      before_install:
+        - wget https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh;
+        - bash miniconda.sh -b -p $HOME/miniconda
+        - export PATH="$HOME/miniconda/bin:$PATH"
+        - conda create -n py36 python=3.6 -y
+      install:
+        - source activate py36
+        - pip install tox
+        - conda install -y --name py36 virtualenv
+      script: tox -e py36
+install: 
+  - pip install tox-travis
+
+script: tox

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,69 @@
+# As config was originally based on an example by Olivier Grisel. Thanks!
+# https://github.com/pyinstaller/pyinstaller/blob/develop/appveyor.yml
+
+clone_depth: 50
+
+environment:
+  PYTEST: py.test -n3 --maxfail 5 --durations=10 --junitxml=junit-results.xml
+  APPVEYOR_SAVE_CACHE_ON_ERROR: true
+
+  matrix:
+    - PYTHON: C:\Python36-x64
+      PYTHON_VERSION: 3.6
+      PYTHON_ARCH: 64
+      
+init:
+  - "ECHO %PYTHON% %PYTHON_VERSION% %PYTHON_ARCH%"
+  - "ECHO \"%APPVEYOR_SCHEDULED_BUILD%\""
+  # If there is a newer build queued for the same PR, cancel this one.
+  # The AppVeyor 'rollout builds' option is supposed to serve the same
+  # purpose but it is problematic because it tends to cancel builds pushed
+  # directly to master instead of just PR builds (or the converse).
+  # credits: JuliaLang developers.
+  - ps: if ($env:APPVEYOR_PULL_REQUEST_NUMBER -and $env:APPVEYOR_BUILD_NUMBER -ne ((Invoke-RestMethod `
+        https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG/history?recordsNumber=50).builds | `
+        Where-Object pullRequestId -eq $env:APPVEYOR_PULL_REQUEST_NUMBER)[0].buildNumber) { `
+          throw "There are newer queued builds for this pull request, failing early." }
+
+cache:
+  # Cache downloaded pip packages and built wheels.
+  - '%LOCALAPPDATA%\pip\Cache\http'
+  - '%LOCALAPPDATA%\pip\Cache\wheels'
+  # Cache Tox envs
+  - 'C:\projects\pytest-localftpserver\.tox'  
+        
+        
+install:
+  # Show size of cache
+  - C:\cygwin\bin\du -hs "%LOCALAPPDATA%\pip\Cache"
+  - C:\cygwin\bin\du -hs "C:\projects\pytest-localftpserver\.tox"
+  # set python path
+  - SET PATH=%PYTHON%;%PYTHON%\Scripts;%PATH%
+
+  # Upgrade to the latest pip.
+  - 'pip install -U pip setuptools wheel'
+  
+  # install tox
+  - 'pip install -U tox'
+
+build: none
+  
+test_script:
+  - "tox"
+
+on_finish:
+  # Remove old or huge cache files to hopefully not exceed the 1GB cache limit.
+  #
+  # If the cache limit is reached, the cache will not be updated (of not even
+  # created in the first run). So this is a trade of between keeping the cache
+  # current and having a cache at all.
+  # NB: This is done only `on_success` since the cache in uploaded only on
+  # success anyway.
+  - C:\cygwin\bin\find "%LOCALAPPDATA%\pip" -type f -mtime +360 -delete
+  - C:\cygwin\bin\find "%LOCALAPPDATA%\pip" -type f -size +10M -delete
+  - C:\cygwin\bin\find "%LOCALAPPDATA%\pip" -empty -delete
+  - C:\cygwin\bin\find "C:\projects\pytest-localftpserver\.tox" -type f -mtime +360 -delete
+  - C:\cygwin\bin\find "C:\projects\pytest-localftpserver\.tox" -empty -delete
+  # Show size of cache
+  - C:\cygwin\bin\du -hs "%LOCALAPPDATA%\pip\Cache"
+  - C:\cygwin\bin\du -hs "C:\projects\pytest-localftpserver\.tox"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ environment:
     - PYTHON: C:\Python36-x64
       PYTHON_VERSION: 3.6
       PYTHON_ARCH: 64
-      
+
 init:
   - "ECHO %PYTHON% %PYTHON_VERSION% %PYTHON_ARCH%"
   - "ECHO \"%APPVEYOR_SCHEDULED_BUILD%\""
@@ -30,9 +30,9 @@ cache:
   - '%LOCALAPPDATA%\pip\Cache\http'
   - '%LOCALAPPDATA%\pip\Cache\wheels'
   # Cache Tox envs
-  - 'C:\projects\pytest-localftpserver\.tox'  
-        
-        
+  - 'C:\projects\pytest-localftpserver\.tox'
+
+
 install:
   # Show size of cache
   - C:\cygwin\bin\du -hs "%LOCALAPPDATA%\pip\Cache"
@@ -41,13 +41,14 @@ install:
   - SET PATH=%PYTHON%;%PYTHON%\Scripts;%PATH%
 
   # Upgrade to the latest pip.
-  - 'pip install -U pip setuptools wheel'
-  
+  # calling pip with "%CMD_IN_ENV% python -m" prevents an access denied error
+  - '%CMD_IN_ENV% python -m pip install -U pip setuptools wheel'
+
   # install tox
-  - 'pip install -U tox'
+  - '%CMD_IN_ENV% python -m pip install -U tox'
 
 build: none
-  
+
 test_script:
   - "tox"
 

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,9 +1,7 @@
-pip==8.1.2
-bumpversion==0.5.3
-wheel==0.29.0
-watchdog==0.8.3
+pip>=8.1.2
+wheel>=0.30.0
 flake8==2.6.0
-tox==2.3.1
-coverage==4.1
-Sphinx==1.4.8
-pytest==3.0.5
+tox>=2.3.1
+coverage>=4.1
+Sphinx>=1.4.8
+pytest>=3.0.5

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,10 @@
 [tox]
-envlist = py{27,34,35,36},flake8	
+envlist = py{27,34,35,36}
 
 [travis]
 os =
   linux: py{27,34,35,36},flake8
-  osx: py{27,34,35,36} 
+  osx: py{27,34,35,36}
 
 [testenv:flake8]
 basepython=python

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,10 @@
 [tox]
-envlist = py26, py27, py33, py34, py35, flake8
+envlist = py{27,34,35,36},flake8	
+
+[travis]
+os =
+  linux: py{27,34,35,36},flake8
+  osx: py{27,34,35,36} 
 
 [testenv:flake8]
 basepython=python
@@ -7,16 +12,5 @@ deps=flake8
 commands=flake8 pytest_localftpserver
 
 [testenv]
-setenv =
-    PYTHONPATH = {toxinidir}:{toxinidir}/pytest_localftpserver
-deps =
-    -r{toxinidir}/requirements_dev.txt
-commands =
-    pip install -U pip
-    py.test --basetemp={envtmpdir}
-
-
-; If you want to make tox run the tests with the same versions, create a
-; requirements.txt with the pinned versions and uncomment the following lines:
-; deps =
-;     -r{toxinidir}/requirements.txt
+deps = -r{toxinidir}/requirements_dev.txt
+commands = py.test --basetemp={envtmpdir}


### PR DESCRIPTION
As mentioned in [#2](https://github.com/oz123/pytest-localftpserver/issues/2) CI would improve the project, so i fiddled around quite a lot to get it work for linux, osx and windows.
The tests are only for Python 2.7, 3.4, 3.5, 3.6 and flake8, since most big Projects like [tox ](https://github.com/tox-dev/tox) itself only test those.

To make it work you would have to log in at [travis-ci](https://travis-ci.org) and [appveyor](https://ci.appveyor.com/) with your git account and add this repo to the projects.
If you want to see what the tests look like with applied [PR#1](https://github.com/oz123/pytest-localftpserver/pull/1), you could check it out on [travis-ci](https://travis-ci.org/s-weigand/pytest-localftpserver/builds/337615462) and [appveyor](https://ci.appveyor.com/project/s-weigand/pytest-localftpserver/build/1.0.10).

Best regards and I hope for your feedback on my changes
Sebastian