### PR TITLE
Fix for cleaning up of temp files

### DIFF
--- a/pytest_localftpserver/plugin.py
+++ b/pytest_localftpserver/plugin.py
@@ -65,7 +65,7 @@ class SimpleFTPServer(FTPServer):
         self.close_all()
         for item in ['_anon_root', '_ftp_home']:
             if hasattr(self, item):
-                shutil.rmtree(self._anon_root, ignore_errors=True)
+                shutil.rmtree(getattr(self, item), ignore_errors=True)
 
 
 class MPFTPServer(multiprocessing.Process):


### PR DESCRIPTION
Changed the temp file deletion in `SimpleFTPServer.stop()`, since it tryed to delete `_anon_root` twice and left `_ftp_home` on the harddrive.