### PR TITLE
Add coveralls.io

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,24 @@
+[run]
+branch = True
+include = pytest_localftpserver/plugin.py
+omit = setup.py
+       pytest_localftpserver/__init__.py
+       tests/*
+
+[report]
+# Regexes for lines to exclude from consideration
+exclude_lines =
+    # Have to re-enable the standard pragma
+    pragma: no cover
+
+    # Don't complain about missing debug-only code:
+    def __repr__
+    if self\.debug
+
+    # Don't complain if tests don't hit defensive assertion code:
+    raise AssertionError
+    raise NotImplementedError
+
+    # Don't complain if non-runnable code isn't run:
+    if 0:
+    if __name__ == .__main__.:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,15 @@ matrix:
   include:
     - python: 3.6
       env: TOXENV=flake8
+      after_success:
+        - echo "done"
+
+    - python: 3.6
+      env: TOXENV=env_var_coverage
+
     - language: generic
       python: 2.7
+      env: osx-py27
       os: osx
       before_install:
         - wget https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh;
@@ -24,12 +31,14 @@ matrix:
         - conda create -n py27 python=2.7 -y
       install:
         - source activate py27
-        - pip install tox
+        - python -m pip install -U pip>=8.1.2
+        - pip install tox coveralls
         - conda install -y --name py27 virtualenv
       script: tox -e py27
 
     - language: generic
       python: 3.4
+      env: osx-py34
       os: osx
       before_install:
         - wget https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh;
@@ -38,12 +47,14 @@ matrix:
         - conda create -n py34 python=3.4 -y
       install:
         - source activate py34
-        - pip install tox
+        - python -m pip install -U pip>=8.1.2
+        - pip install tox coveralls
         - conda install -y --name py34 virtualenv
       script: tox -e py34
 
     - language: generic
       python: 3.5
+      env: osx-py35
       os: osx
       before_install:
         - wget https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh;
@@ -52,12 +63,14 @@ matrix:
         - conda create -n py35 python=3.5 -y
       install:
         - source activate py35
-        - pip install tox
+        - python -m pip install -U pip>=8.1.2
+        - pip install tox coveralls
         - conda install -y --name py35 virtualenv
       script: tox -e py35
 
     - language: generic
       python: 3.6
+      env: osx-py36
       os: osx
       before_install:
         - wget https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh -O miniconda.sh;
@@ -66,10 +79,27 @@ matrix:
         - conda create -n py36 python=3.6 -y
       install:
         - source activate py36
-        - pip install tox
+        - python -m pip install -U pip>=8.1.2
+        - pip install tox coveralls
         - conda install -y --name py36 virtualenv
       script: tox -e py36
+
+    - python: 3.6
+      env: win_coverage
+      install:
+        - pip install git+https://github.com/Robpol86/appveyor-artifacts.git coveralls
+      script:
+        - appveyor-artifacts -m download
+      after_success:
+        - coveralls
+        - coverage erase
+
 install:
-  - pip install tox-travis
+  - python -m pip install -U pip>=8.1.2
+  - pip install tox-travis coveralls
 
 script: tox
+
+after_success:
+    - coveralls
+    - coverage erase

--- a/README.rst
+++ b/README.rst
@@ -17,6 +17,11 @@ PyTest FTP Server
      :target: https://pyup.io/repos/github/oz123/pytest_localftpserver/
      :alt: Updates
 
+.. image:: https://coveralls.io/repos/github/oz123/pytest-localftpserver/badge.svg
+     :target: https://coveralls.io/github/oz123/pytest-localftpserver
+     :alt: Coverage
+
+
 
 A PyTest plugin which provides an FTP fixture for your tests
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,6 +5,8 @@ clone_depth: 50
 
 environment:
   PYTEST: py.test -n3 --maxfail 5 --durations=10 --junitxml=junit-results.xml
+  # uncomment to disable cache restore
+#  APPVEYOR_CACHE_SKIP_RESTORE: true
   APPVEYOR_SAVE_CACHE_ON_ERROR: true
 
   matrix:
@@ -35,8 +37,8 @@ cache:
 
 install:
   # Show size of cache
-  - C:\cygwin\bin\du -hs "%LOCALAPPDATA%\pip\Cache"
-  - C:\cygwin\bin\du -hs "C:\projects\pytest-localftpserver\.tox"
+  - if exist "%LOCALAPPDATA%\pip\Cache" C:\cygwin\bin\du -hs "%LOCALAPPDATA%\pip\Cache"
+  - if exist "C:\projects\pytest-localftpserver\.tox" C:\cygwin\bin\du -hs "C:\projects\pytest-localftpserver\.tox"
   # set python path
   - SET PATH=%PYTHON%;%PYTHON%\Scripts;%PATH%
 
@@ -45,14 +47,20 @@ install:
   - '%CMD_IN_ENV% python -m pip install -U pip setuptools wheel'
 
   # install tox
-  - '%CMD_IN_ENV% python -m pip install -U tox'
+  - '%CMD_IN_ENV% python -m pip install -U tox coverage codecov'
 
 build: none
 
 test_script:
-  - "tox"
+  # delete old .coverage file
+  - coverage erase
+  - tox
+
+artifacts:
+  - path: .coverage
 
 on_finish:
+  - codecov
   # Remove old or huge cache files to hopefully not exceed the 1GB cache limit.
   #
   # If the cache limit is reached, the cache will not be updated (of not even

--- a/pytest_localftpserver/plugin.py
+++ b/pytest_localftpserver/plugin.py
@@ -96,19 +96,16 @@ class BaseMPFTPServer(object):
 
     @property
     def server_port(self):
-        return self._server._ftp_port
+        return self._server.ftp_port
 
     @property
     def server_home(self):
         """FTP home for the ftp_user"""
-        if hasattr(self._server, "_ftp_home"):
-            return self._server._ftp_home
-        else:
-            return None
+        return self._server.ftp_home
 
     @property
     def anon_root(self):
-        return self._server._anon_root
+        return self._server.anon_root
 
     def stop(self):
         self._server.stop()

--- a/pytest_localftpserver/plugin.py
+++ b/pytest_localftpserver/plugin.py
@@ -91,6 +91,8 @@ class BaseMPFTPServer(object):
 
         self._server = SimpleFTPServer(username, password,
                                        ftp_home, ftp_port)
+        self.username = self._server.username
+        self.password = self._server.password
 
     @property
     def server_port(self):

--- a/pytest_localftpserver/plugin.py
+++ b/pytest_localftpserver/plugin.py
@@ -32,7 +32,11 @@ class SimpleFTPServer(FTPServer):
         # Create temp directories for the anonymous and authenticated roots
         self._anon_root = tempfile.mkdtemp()
         if not ftp_home:
-            self._ftp_home = tempfile.mkdtemp()
+            self.temp_ftp_home = True
+            self._ftp_home = tempfile.mkdtemp(prefix="ftp_home_")
+        else:
+            self.temp_ftp_home = False
+            self._ftp_home = ftp_home
         self.username = username
         self.password = password
         authorizer = DummyAuthorizer()
@@ -70,9 +74,15 @@ class SimpleFTPServer(FTPServer):
 
     def stop(self):
         self.close_all()
-        for item in ['_anon_root', '_ftp_home']:
-            if hasattr(self, item):
-                shutil.rmtree(getattr(self, item), ignore_errors=True)
+        self.clear_tmp_dirs()
+
+    def clear_tmp_dirs(self):
+        """
+        Clears all temp files generated on the FTP server
+        """
+        shutil.rmtree(self._anon_root, ignore_errors=True)
+        if self.temp_ftp_home:
+            shutil.rmtree(self._ftp_home, ignore_errors=True)
 
 
 class BaseMPFTPServer(object):

--- a/tests/test_pytest_localftpserver_with_env_var.py
+++ b/tests/test_pytest_localftpserver_with_env_var.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import os
+
+def test_set_server_home(ftpserver):
+    assert ftpserver.server_port == 31175
+    assert ftpserver.username ==  "benz"
+    assert ftpserver.password ==  "erni1"
+    assert ftpserver.server_home ==  os.getenv("FTP_HOME")
+
+

--- a/tox.ini
+++ b/tox.ini
@@ -1,16 +1,38 @@
 [tox]
-envlist = py{27,34,35,36}
+envlist = py{27,34,35,36}, flake8
+
 
 [travis]
 os =
-  linux: py{27,34,35,36},flake8
+  linux: py{27,34,35,36}, env_var_coverage, flake8
   osx: py{27,34,35,36}
+
+
+[flake8]
+max-line-length = 99
+
 
 [testenv:flake8]
 basepython=python
 deps=flake8
 commands=flake8 pytest_localftpserver
 
+
+[testenv:env_var_coverage]
+passenv = *
+setenv =
+    FTP_USER = benz
+    FTP_PASS = erni1
+    FTP_HOME = {envtmpdir}
+    FTP_PORT = 31175
+commands =
+    coverage run --append -m py.test tests/test_pytest_localftpserver_with_env_var.py
+    coverage report --show-missing
+
+
 [testenv]
+passenv = *
 deps = -r{toxinidir}/requirements_dev.txt
-commands = py.test --basetemp={envtmpdir}
+commands =
+    coverage run --append -m py.test tests/test_pytest_localftpserver.py
+    coverage report --show-missing


### PR DESCRIPTION
This PR adds a coverage badge and allows a detailed inspection of which part of the code was run by which testenv. 
For it to work you need to log in at [coveralls.io/](https://coveralls.io/) with your git account and add the project.

The usage of env variables is done in an extra tox env and not with `pytest-env`, since `pytest-cov` has [problems testing the coverage of pytest-plugins ](https://pytest-cov.readthedocs.io/en/latest/plugins.html).