### PR TITLE
Fixed dependency versions so pyup will work

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -5,8 +5,8 @@ watchdog>=0.8.3
 Sphinx>=1.7.5
 sphinx-rtd-theme>=0.3.1
 # testing
-pytest>=3.0.5
+pytest==3.0.5
 flake8>=2.6.0
-tox>=2.3.1
+tox==2.3.1
 coverage>=4.3.0
 wget>=3.2


### PR DESCRIPTION
Sorry for the delay, but here is the PR promissed in #12 .
With this the PRs from pyup will indicate if updates from `tox` or `pytest`, will break the plugin.