### PR TITLE
fix flake8 problem

### DIFF
--- a/pytest_localftpserver/helper_functions.py
+++ b/pytest_localftpserver/helper_functions.py
@@ -215,7 +215,7 @@ def arg_validator(func_locals, valid_var_dict, valid_var_overwrite=None,
                                  "{value_string}, the given value was "
                                  "{val}.".format(**msg_dict))
         # this is a convenience functionality, for implementing new functions
-        if not found_entry and dev_mode and key is not "self":
+        if not found_entry and dev_mode and key != "self":
             warn_msg = "`valid_var_list` in `{}` is missing an entry, " \
                        "where entry['name']=={}, this entry won't be " \
                        "validated.".format(implementation_func_name, key)

--- a/pytest_localftpserver/plugin.py
+++ b/pytest_localftpserver/plugin.py
@@ -906,7 +906,7 @@ class BaseMPFTPServer(object):
                     dirs, filename = os.path.split(file_path_local["dest"])
                     dir_path = os.path.abspath(os.path.join(base_path, dirs))
                     # strip is needed in case dirs is " "
-                    if dirs.strip() is not "" and not os.path.isdir(dir_path):
+                    if dirs.strip() != "" and not os.path.isdir(dir_path):
                         os.makedirs(dir_path)
                     file_path_local = file_path_local["src"]
                     file_path = os.path.abspath(os.path.join(base_path, dir_path, filename))

--- a/tests/test_pytest_localftpserver.py
+++ b/tests/test_pytest_localftpserver.py
@@ -105,7 +105,7 @@ def check_files_by_ftpclient(ftpserver, tmpdir, files_on_server, path_iterable, 
         assert os.path.isfile(abs_file_path)
         assert file_path in files_on_server
         dirs, filename = os.path.split(file_path)
-        if dirs is not "":
+        if dirs != "":
             download_file = download_dir.mkdir(dirs).join(filename)
         else:
             download_file = download_dir.join(filename)
@@ -337,7 +337,7 @@ def test_get_file_paths(tmpdir, ftpserver, anon):
     files_on_server = []
     for dirs, filename in FILE_LIST:
         dir_path = os.path.abspath(os.path.join(base_path, dirs))
-        if dirs is not "":
+        if dirs != "":
             os.makedirs(dir_path)
         abs_file_path = os.path.join(dir_path, filename)
         file_path = "/".join([dirs, filename]).lstrip("/")
@@ -396,7 +396,7 @@ def test_get_file_contents(tmpdir, ftpserver, anon, file_rel_paths, style, read_
     files_on_server = []
     for dirs, filename in FILE_LIST:
         dir_path = os.path.abspath(os.path.join(base_path, dirs))
-        if dirs is not "":
+        if dirs != "":
             os.makedirs(dir_path)
         abs_file_path = os.path.join(dir_path, filename)
         file_path = "/".join([dirs, filename]).lstrip("/")
@@ -501,7 +501,7 @@ def test_put_files(tmpdir, ftpserver, use_dict, style, anon, overwrite,
     files_on_local = []
     local_dir = tmpdir.mkdir("local_dir")
     for dirs, filename in FILE_LIST:
-        if dirs is not "":
+        if dirs != "":
             test_file = local_dir.mkdir(dirs).join(filename)
         else:
             test_file = local_dir.join(filename)


### PR DESCRIPTION
The new version of flake8, enforces to change `is not` to `!=` for some types.
```
F632 use ==/!= to compare str, bytes, and int literals
```
With this changes the build should pass.