### PR TITLE
Fix problems with the api docs on readthedocs v2

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,6 +14,9 @@ end_of_line = lf
 indent_style = tab
 end_of_line = crlf
 
+[*.yml]
+indent_size = 2
+
 [LICENSE]
 insert_final_newline = false
 

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,6 +1,3 @@
-build:
-  image: latest
-
 python:
-  version: 3.6
+  version: 3.5
   setup_py_install: true

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ with open('HISTORY.rst') as history_file:
 
 requirements = [
     'pyftpdlib',
+    'pytest'
 ]
 
 test_requirements = [


### PR DESCRIPTION
The fix in #17 didn't work and api docs still didn't generate properly.
So I deconfigured one of my projects in the web UI and played a bit around with the `readthedocs.yml`, to see whats going on.
Apearently rtd has atm problems with their docker images [see](https://github.com/rtfd/readthedocs.org/issues/4446). While derping around with `readthedocs.yml` and the [new specs](https://docs.readthedocs.io/en/latest/config-file/v2.html) for it, I found that the new specs just got [deactivated](https://github.com/rtfd/readthedocs.org/commit/4e3079529d8e453c51d2cb15b67d5f206c445d78), but this [solution](https://github.com/rtfd/readthedocs.org/issues/4446#issuecomment-409088015) worked for me aswell in the end.
But this solution might change in the future when they have their v2 specs running properly.

I also added `pytest` as requirement to the `setup.py` to make sure  `pytest-localftpserver` will be installed properly on rtd. Guess this sliped till now, since it was allways imported for testing and `pytest-localftpserver` (as the name says) can't be used as intended w/o `pytest`.

I hope this will get the api docs up and running now. :sweat:
