### PR TITLE
Force Tox to updated dev deps

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,6 +14,9 @@ end_of_line = lf
 indent_style = tab
 end_of_line = crlf
 
+[*.yml]
+indent_size = 2
+
 [LICENSE]
 insert_final_newline = false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,40 +21,14 @@ matrix:
       env: TOXENV=env_var_coverage
 
     - python: 3.6
-      #taken from https://quick-sphinx-tutorial.readthedocs.io/en/latest/advanced.html
-      branches:
-        only:
-          - master
-      env: test-doc-creation
-      sudo: false
-      install:
-        - python -m pip install -U -r requirements_dev.txt
-        - python setup.py install
-      script:
-        - cd docs; make html
-      # Flags used here, not in `make html`:
-      #  -n   Run in nit-picky mode. Currently, this generates warnings for all missing references.
-      #  -W   Turn warnings into errors. This means that the build stops at the first warning and sphinx-build exits with exit status 1.
+      env: TOXENV=docs
       after_success:
         - echo "done"
 
     - python: 3.6
-        #taken from https://quick-sphinx-tutorial.readthedocs.io/en/latest/advanced.html
-      branches:
-          only:
-          - master
-      env: test-doc-links
-      sudo: false
-      install:
-      - python -m pip install -U -r requirements_dev.txt
-      - python setup.py install
-      script:
-      - cd docs; make linkcheck
-          # Flags used here, not in `make html`:
-      #  -n   Run in nit-picky mode. Currently, this generates warnings for all missing references.
-        #  -W   Turn warnings into errors. This means that the build stops at the first warning and sphinx-build exits with exit status 1.
+      env: TOXENV=docs-links
       after_success:
-      - echo "done"
+        - echo "done"
 
     - language: python
       sudo: required
@@ -159,7 +133,7 @@ matrix:
 
   allow_failures:
 #      this test is allowed to fail since it uses external resources
-    - env: test-doc-links
+    - env: TOXENV=docs-links
 
 install:
   - python -m pip install -U pip>=8.1.2

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,34,35,36,37}, env_var_coverage, flake8
+envlist = py{27,34,35,36,37}, env_var_coverage, flake8, docs, docs-links
 
 
 [travis]
@@ -12,6 +12,17 @@ os =
 max-line-length = 99
 
 
+[testenv:docs]
+whitelist_externals = make
+commands =
+    make --directory=docs clean_all html
+
+[testenv:docs-links]
+whitelist_externals = make
+commands =
+    make --directory=docs clean_all linkcheck
+
+
 [testenv:flake8]
 basepython=python
 deps=flake8
@@ -19,12 +30,12 @@ commands=flake8 pytest_localftpserver tests
 
 
 [testenv:env_var_coverage]
-passenv = *
 setenv =
     FTP_USER = benz
     FTP_PASS = erni1
     FTP_HOME = {envtmpdir}
     FTP_PORT = 31175
+commands_pre = {envpython} -m pip install -U -q -r {toxinidir}/requirements_dev.txt
 commands =
     coverage run --append -m py.test --basetemp={envtmpdir} tests/test_pytest_localftpserver_with_env_var.py
     coverage report --show-missing
@@ -33,6 +44,7 @@ commands =
 [testenv]
 passenv = *
 deps = -r{toxinidir}/requirements_dev.txt
+commands_pre = {envpython} -m pip install -U -q -r {toxinidir}/requirements_dev.txt
 commands =
     coverage run --append -m py.test --basetemp={envtmpdir} tests/test_pytest_localftpserver.py tests/test_helper_functions.py
     coverage report --show-missing


### PR DESCRIPTION
On my last PR I saw that my appveyor failed due to an old `pytest` version in the cached tox env.
This chaching behaviour renders the use of pyup useless, which is why I modified the `tox.ini` to force install updated dependencies before testing.
I also moved testing the docs to tox, so contributers can easiely see if they break the docs.