### PR TITLE
Allow travis test 'win-coverage' to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -132,8 +132,9 @@ matrix:
         - coverage erase
 
   allow_failures:
-#      this test is allowed to fail since it uses external resources
+#      this tests are allowed to fail since they rely external resources
     - env: TOXENV=docs-links
+    - env: win-coverage
 
 install:
   - python -m pip install -U pip>=8.1.2


### PR DESCRIPTION
Since `win-coverage` isn't an accual test, but just down- and uploads the coverage from appveyor to coveralls.io it shouldn't make the [travis test suite fail](https://travis-ci.org/oz123/pytest-localftpserver/builds/494226520?utm_source=github_status&utm_medium=notification). Especially since the PyPi version the tool used for that porpouse was [last updated 2016](https://pypi.org/project/appveyor-artifacts/) and is broken, which is why the [git master version](https://github.com/oz123/pytest-localftpserver/blob/1d0dcd1c0017b6c99a7957201841728c3f2140c1/.travis.yml#L127) of it is used.