### PR TITLE
Make a release for legacy python versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,6 @@ target/
 
 # pyenv python configuration file
 .python-version
+
+# vs-code config files
+.vscode

--- a/README.rst
+++ b/README.rst
@@ -4,12 +4,12 @@ PyTest FTP Server
 
 
 .. image:: https://img.shields.io/pypi/v/pytest_localftpserver.svg
-        :target: https://pypi.python.org/pypi/pytest_localftpserver
+        :target:  https://pypi.org/project/pytest-localftpserver/
 
 .. image:: https://img.shields.io/pypi/pyversions/pytest_localftpserver.svg
     :target: https://pypi.org/project/pytest/
 
-.. image:: https://travis-ci.org/oz123/pytest-localftpserver.svg?branch=master
+.. image:: https://api.travis-ci.org/oz123/pytest-localftpserver.svg?branch=master
         :target: https://travis-ci.org/oz123/pytest-localftpserver
 
 .. image:: https://ci.appveyor.com/api/projects/status/github/oz123/pytest-localftpserver?svg=true
@@ -103,7 +103,7 @@ Sample config for Tox::
 Credits
 =======
 
-This package was inspired by, https://pypi.python.org/pypi/pytest-localserver/
+This package was inspired by,  https://pypi.org/project/pytest-localserver/
 made by Sebastian Rahlf, which lacks an FTP server.
 
 This package was created with Cookiecutter_ and the `audreyr/cookiecutter-pypackage`_ project template.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -20,7 +20,7 @@ If you don't have `pip`_ installed, this `Python installation guide`_ can guide
 you through the process.
 
 .. _pip: https://pip.pypa.io/en/stable/
-.. _Python installation guide: http://docs.python-guide.org/en/latest/starting/installation/
+.. _Python installation guide: https://docs.python-guide.org/starting/installation/
 
 
 From sources

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -5,7 +5,7 @@ watchdog>=0.8.3
 # install requirements
 pyftpdlib==1.5.5
 PyOpenSSL==19.0.0
-pytest==5.0.0
+pytest==4.6.4
 
 # documentation
 Sphinx>=1.7.5


### PR DESCRIPTION
Hi Oz, 
since the merge of PR #49 the tests are broken, because `pytests>=5. 0.0` dropped support for legacy python versions (namely in this case `py27` and `py34`).
This PR will pass the tests and should be the release candidate for a minor version (i.e. `0. 6.0`), so please bump the version after the merge.
To get up to date again, I will make a PR that drops all legacy code and make a note for users to use this release if they need support for older python versions. 

P.S.: If you also stopped using py27 we could also upgrade `bumpversion` to [`bump2version`](https://github.com/c4urself/bump2version), which is a fork of  `bumpversion` which is still maintained and supports python 2+3.