### PR TITLE
change the instructions to install the version for legacy py

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,7 @@ Attention!
 ==========
 
 As of version ``1.0.0`` the support for python 2.7 and 3.4 was dropped.
-If you need to support those versions you should pin the version to ``0.0.6``,
+If you need to support those versions you should pin the version to ``0.6.0``,
 i.e. add the following lines to your "requirements_dev.txt"::
 
         # pytest_localftpserver==0.6.0

--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,11 @@ Attention!
 ==========
 
 As of version ``1.0.0`` the support for python 2.7 and 3.4 was dropped.
-If you need to support those versions you should pin the version ``pytest_localftpserver==0.6.0``.
+If you need to support those versions you should pin the version to ``0.0.6``,
+i.e. add the following lines to your "requirements_dev.txt"::
+
+        # pytest_localftpserver==0.6.0
+        https://github.com/oz123/pytest-localftpserver/archive/v0.6.0.zip
 
 
 Usage Quickstart:


### PR DESCRIPTION
Adapted the instuctions to install version `0.6.0`, to the tag only release.