### PR TITLE
Update docs

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -59,16 +59,16 @@ Get Started!
 
 Ready to contribute? Here's how to set up `pytest_localftpserver` for local development.
 
-1. Fork the `pytest_localftpserver` repo on GitHub.
+1. Fork the `pytest-localftpserver` repo on GitHub.
 2. Clone your fork locally::
 
-    $ git clone git@github.com:your_name_here/pytest_localftpserver.git
+    $ git clone git@github.com:your_name_here/pytest-localftpserver.git
 
 3. Install your local copy into a virtualenv. Assuming you have virtualenvwrapper installed,
    this is how you set up your fork for local development::
 
     $ mkvirtualenv pytest_localftpserver
-    $ cd pytest_localftpserver/
+    $ cd pytest-localftpserver/
     $ pip install -r requirements_dev.txt
     $ python setup.py develop
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -113,3 +113,14 @@ To run a subset of tests::
 
     $ py.test tests/test_pytest_localftpserver.py::<test_name>
 
+
+Deploying
+---------
+
+A reminder for the maintainers on how to deploy.
+Make sure all your changes are committed (including an entry in HISTORY.rst).
+Then run::
+
+$ bump2version patch # possible: major / minor / patch
+$ git push --follow-tags
+

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -102,7 +102,7 @@ Before you submit a pull request, check that it meets these guidelines:
 2. If the pull request adds functionality, the docs should be updated. Put
    your new functionality into a function with a docstring, and add the
    feature to the list in README.rst.
-3. The pull request should work for Python 2.7, 3.4, 3.5 and 3.6 . Check
+3. The pull request should work for Python 3.5, 3.6 and 3.7 . Check
    https://travis-ci.org/oz123/pytest-localftpserver/pull_requests
    and make sure that the tests pass for all supported Python versions.
 

--- a/README.rst
+++ b/README.rst
@@ -54,18 +54,18 @@ This Plugin provides the fixtures ``ftpserver`` and ``ftpserver_TLS``,
 which are threaded instances of a FTP server, with which you can upload files and test FTP
 functionality. It can be configured using the following environment variables:
 
-=====================   =====================================================================
+=====================   =============================================================================
 Environment variable    Usage
-=====================   =====================================================================
+=====================   =============================================================================
 ``FTP_USER``            Username of the registered user.
 ``FTP_PASS``            Password of the registered user.
 ``FTP_PORT``            Port for the normal ftp server to run on.
-``FTP_HOME``            Home folder of the registered user.
+``FTP_HOME``            Home folder (host system) of the registered user.
 ``FTP_FIXTURE_SCOPE``   Scope/lifetime of the fixture.
 ``FTP_PORT_TLS``        Port for the TLS ftp server to run on.
-``FTP_HOME_TLS``        Home folder of the registered user, used by the TLS ftp server.
-``FTP_CERTFILE``        Certificate to be used by the TLS ftp server.
-=====================   =====================================================================
+``FTP_HOME_TLS``        Home folder (host system) of the registered user, used by the TLS ftp server.
+``FTP_CERTFILE``        Certificate (host system) to be used by the TLS ftp server.
+=====================   =============================================================================
 
 
 See the `tests directory <https://github.com/oz123/pytest-localftpserver/tree/master/tests>`_

--- a/README.rst
+++ b/README.rst
@@ -93,7 +93,7 @@ Sample config for Tox::
 
     $ cat tox.ini
     [tox]
-    envlist = py{27,34,35,36,37}
+    envlist = py{35,36,37}
 
     [testenv]
     setenv =

--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,7 @@ A PyTest plugin which provides an FTP fixture for your tests
 * Documentation: https://pytest-localftpserver.readthedocs.io/en/latest/index.html
 
 Attention!
-==========
+^^^^^^^^^^
 
 As of version ``1.0.0`` the support for python 2.7 and 3.4 was dropped.
 If you need to support those versions you should pin the version to ``0.6.0``,
@@ -48,7 +48,7 @@ i.e. add the following lines to your "requirements_dev.txt"::
 
 
 Usage Quickstart:
-=================
+^^^^^^^^^^^^^^^^^
 
 This Plugin provides the fixtures ``ftpserver`` and ``ftpserver_TLS``,
 which are threaded instances of a FTP server, with which you can upload files and test FTP
@@ -113,7 +113,7 @@ Sample config for Tox::
         py.test tests
 
 Credits
-=======
+^^^^^^^
 
 This package was inspired by,  https://pypi.org/project/pytest-localserver/
 made by Sebastian Rahlf, which lacks an FTP server.

--- a/README.rst
+++ b/README.rst
@@ -5,6 +5,9 @@ PyTest FTP Server
 .. image:: https://img.shields.io/pypi/v/pytest_localftpserver.svg
         :target:  https://pypi.org/project/pytest-localftpserver/
 
+.. image:: https://camo.githubusercontent.com/89b9f56d30241e30f546daf9f43653f08e920f16/68747470733a2f2f696d672e736869656c64732e696f2f636f6e64612f766e2f636f6e64612d666f7267652f7079746573742d6c6f63616c6674707365727665722e737667
+        :target:  https://anaconda.org/conda-forge/pytest-localftpserver
+
 .. image:: https://img.shields.io/pypi/pyversions/pytest_localftpserver.svg
     :target: https://pypi.org/project/pytest/
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -43,7 +43,8 @@ import pytest_localftpserver
 extensions = ['sphinx.ext.autodoc',
               'sphinx.ext.autosummary',
               'sphinx.ext.viewcode',
-              'sphinx.ext.napoleon']
+              'sphinx.ext.napoleon',
+              'sphinx_copybutton']
 
 autoclass_content = "both"
 autosummary_generate = True
@@ -122,6 +123,10 @@ pygments_style = 'sphinx'
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
 html_theme = 'sphinx_rtd_theme'
+
+# CopyButton configuration
+copybutton_prompt_text = r">>> |\.\.\. |\$ "
+copybutton_prompt_is_regexp = True
 
 # Theme options are theme-specific and customize the look and feel of a
 # theme further.  For a list of options available for each theme, see the

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -14,12 +14,19 @@ To install PyTest FTP Server, run this command in your terminal:
 
     $ pip install pytest-localftpserver
 
-This is the preferred method to install PyTest FTP Server, as it will always install the most recent stable release.
-
 If you don't have `pip`_ installed, this `Python installation guide`_ can guide
 you through the process.
 
+Or if you prefer to use `conda`_:
+
+.. code-block:: console
+
+    $ conda install -c conda-forge pytest-localftpserver
+
+This are the preferred methods to install PyTest FTP Server, as it will always install the most recent stable release.
+
 .. _pip: https://pip.pypa.io/en/stable/
+.. _conda: https://www.anaconda.com/products/individual
 .. _Python installation guide: https://docs.python-guide.org/starting/installation/
 
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -342,7 +342,7 @@ For the encrypted version of the fixture it uses port ``31176`` and the certific
 
     $ cat tox.ini
     [tox]
-    envlist = py{27,34,35,36,37}
+    envlist = py{35,36,37}
 
     [testenv]
     setenv =

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -282,18 +282,18 @@ variables ``FTP_USER``, ``FTP_PASS``, ``FTP_PORT``, ``FTP_HOME``, ``FTP_FIXTURE_
 ``FTP_PORT_TLS``, ``FTP_HOME_TLS`` and ``FTP_CERTFILE``.
 
 
-=====================   =====================================================================
+=====================   =============================================================================
 Environment variable    Usage
-=====================   =====================================================================
+=====================   =============================================================================
 ``FTP_USER``            Username of the registered user.
 ``FTP_PASS``            Password of the registered user.
 ``FTP_PORT``            Port for the normal ftp server to run on.
-``FTP_HOME``            Home folder of the registered user.
+``FTP_HOME``            Home folder (host system) of the registered user.
 ``FTP_FIXTURE_SCOPE``   Scope/lifetime of the fixture.
 ``FTP_PORT_TLS``        Port for the TLS ftp server to run on.
-``FTP_HOME_TLS``        Home folder of the registered user, used by the TLS ftp server.
-``FTP_CERTFILE``        Certificate to be used by the TLS ftp server.
-=====================   =====================================================================
+``FTP_HOME_TLS``        Home folder (host system) of the registered user, used by the TLS ftp server.
+``FTP_CERTFILE``        Certificate (host system) to be used by the TLS ftp server.
+=====================   =============================================================================
 
 You can either set environment variables on a system level or use tools such as
 `pytest-env <https://pypi.org/project/pytest-env/>`_ or

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -334,7 +334,7 @@ Configuration with Tox
 
 The configuration of tox is done in the ``tox.ini`` file.
 The following example configuration will run the tests in the folder ``tests`` on
-python 2.7, 3.4, 3.5, 3.6 and 3.7 and use the username ``benz``, the password ``erni1``,
+python 3.5, 3.6 and 3.7 and use the username ``benz``, the password ``erni1``,
 the tempfolder of each virtual environment the tests are run in (``{envtmpdir}``) and
 the ftp port ``31175``.
 For the encrypted version of the fixture it uses port ``31176`` and the certificate

--- a/pytest_localftpserver/__init__.py
+++ b/pytest_localftpserver/__init__.py
@@ -2,4 +2,4 @@
 
 __author__ = """Oz Tiram"""
 __email__ = 'oz.tiram@gmail.com'
-__version__ = '1.0.0'
+__version__ = '1.0.1'

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,3 +1,13 @@
+version: 2
+
+formats: all
+
+build:
+  image: latest
+
 python:
-  version: 3.5
-  setup_py_install: true
+  version: 3.7
+  install:
+    - requirements: requirements_dev.txt
+    - method: pip
+      path: .

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -7,8 +7,9 @@ PyOpenSSL==19.1.0
 pytest==6.0.1
 
 # documentation
-Sphinx>=1.7.5
-sphinx-rtd-theme>=0.3.1
+Sphinx>=1.8
+sphinx-copybutton>=0.3.0
+sphinx-rtd-theme>=0.5.0
 
 # testing
 flake8>=2.6.0

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,6 +1,5 @@
 bump2version>=0.5.10
 wheel>=0.30.0
-watchdog>=0.8.3
 
 # install requirements
 pyftpdlib==1.5.6


### PR DESCRIPTION
Changes in the PR are:
- `readthedocs.yml` was updated to version 2 specs, since [version 1 is deprecated](https://docs.readthedocs.io/en/stable/config-file/v1.html)
- Explicitly mention that `FTP_HOME`, `FTP_HOME_TLS` and `FTP_CERTFILE` are on the host system
- References  to deprecated python versions (py27 and py34) were removed
- Urls and paths in the contributing guide were fixed
- `sphinx-copybutton` addon was added to the docs so users can quickly copy example code
- Added badge to the package on `conda-forge` and added conda installation guide
- Made subsections in readme actual subsections
- Removed watchdog from dev dependencies, since it is just an artifact from the cookiecutter template
- Manually bumped `__version __` in `pytest_localftpserver/__init__.py` to `1.0.1`, since it was still `1.0.0`
- Added deployment reminder to contributing docs
