### PR TITLE
Use dependabot for updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: pip
+    directory: '/'
+    schedule:
+      interval: weekly
+      day: friday
+      time: "18:00"
+    reviewers:
+      - oz123
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: weekly
+      day: friday
+      time: "18:00"
+    reviewers:
+      - oz123

--- a/README.rst
+++ b/README.rst
@@ -21,8 +21,8 @@ PyTest FTP Server
         :target: https://pytest-localftpserver.readthedocs.io/en/latest/?badge=latest
         :alt: Documentation Status
 
-.. image:: https://pyup.io/repos/github/oz123/pytest-localftpserver/shield.svg
-        :target: https://pyup.io/repos/github/oz123/pytest-localftpserver/
+.. image:: https://api.dependabot.com/badges/status?host=github&repo=oz123/pytest-localftpserver
+        :target: https://dependabot.com
         :alt: Updates
 
 .. image:: https://coveralls.io/repos/github/oz123/pytest-localftpserver/badge.svg


### PR DESCRIPTION
Dependabot is an alternative to pyup and [it recently got integrated into github](https://github.blog/2020-06-01-keep-all-your-packages-up-to-date-with-dependabot/).

Advantages over pyup:
- PRs contain change summary
- Bot cleans up PR branches after merge (atm you have 25 pyup PR branches, 24 of them already merged)
- Autoclose PR if it got superseded by a new one
- Autorebase PR on conflict

The only downside is that the [badge is currently broken](https://github.com/dependabot/dependabot-core/issues/1912)

The `github-actions` section was added due to #105 

