### PR TITLE
Fix typo on `.daemon` attribute

### DIFF
--- a/pytest_localftpserver/servers.py
+++ b/pytest_localftpserver/servers.py
@@ -1089,7 +1089,7 @@ class ThreadFTPServer(FunctionalityWrapper):
         # The server needs to run in a separate thread or it will block all tests
         self.thread = threading.Thread(target=self._server.serve_forever)
         # This is a must in order to clear used sockets
-        self.thread.deamon = True
+        self.thread.daemon = True
         self.thread.start()
 
     def stop(self):
@@ -1108,7 +1108,7 @@ class ProcessFTPServer(FunctionalityWrapper):
         # The server needs to run in a separate process or it will block all tests
         self.process = multiprocessing.Process(target=self._server.serve_forever)
         # This is a must in order to clear used sockets
-        self.process.deamon = True
+        self.process.daemon = True
         self.process.start()
 
     def stop(self):


### PR DESCRIPTION
Looks like there is a typo in `.daemon` attribute.

See : 
- threading : https://docs.python.org/3/library/threading.html#threading.Thread.daemon
- multiprocessing : https://docs.python.org/3/library/multiprocessing.html#multiprocessing.Process.daemon
