### PR TITLE
👌 Allow multiple instances at the same time

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -369,6 +369,10 @@ If you need multiple instances of an FTP server for testing
 (e.g. your code transfers data from one server to another)
 you can create an additional fixture.
 
+.. note::
+
+    Currently multiple TLS servers are only supported on Linux.
+
 
 .. code-block:: python
     :caption: tests/test_ftp_copy.py

--- a/pytest_localftpserver/servers.py
+++ b/pytest_localftpserver/servers.py
@@ -33,7 +33,7 @@ class WrongFixtureError(Exception):
     pass
 
 
-def create_ftp_handler():
+def create_ftp_handler(use_TLS=False):
     """
     Create on the fly Handler class inside of a closure.
 
@@ -41,9 +41,18 @@ def create_ftp_handler():
     Ref:
     https://github.com/giampaolo/pyftpdlib/issues/454
     """
-    class FTPHandlerMulti(FTPHandler):
-        pass
-    return FTPHandlerMulti
+    if use_TLS:
+
+        class FTPHandlerTLSMulti(TLS_FTPHandler):
+            pass
+
+        return FTPHandlerTLSMulti
+    else:
+
+        class FTPHandlerMulti(FTPHandler):
+            pass
+
+        return FTPHandlerMulti
 
 
 class SimpleFTPServer(FTPServer):
@@ -92,11 +101,11 @@ class SimpleFTPServer(FTPServer):
         self._cert_path = certfile
 
         if use_TLS:
-            handler = TLS_FTPHandler
+            handler = create_ftp_handler(use_TLS=True)
             handler.certfile = certfile
             validate_cert_file(certfile)
         else:
-            handler = create_ftp_handler()
+            handler = create_ftp_handler(use_TLS=False)
 
         socket, self._ftp_port = get_socket(ftp_port)
 

--- a/pytest_localftpserver/servers.py
+++ b/pytest_localftpserver/servers.py
@@ -33,6 +33,19 @@ class WrongFixtureError(Exception):
     pass
 
 
+def create_ftp_handler():
+    """
+    Create on the fly Handler class inside of a closure.
+
+    This prevents the authorizer to ve overwritten on a class variable level.
+    Ref:
+    https://github.com/giampaolo/pyftpdlib/issues/454
+    """
+    class FTPHandlerMulti(FTPHandler):
+        pass
+    return FTPHandlerMulti
+
+
 class SimpleFTPServer(FTPServer):
     """
     Starts a simple FTP server.
@@ -83,7 +96,7 @@ class SimpleFTPServer(FTPServer):
             handler.certfile = certfile
             validate_cert_file(certfile)
         else:
-            handler = FTPHandler
+            handler = create_ftp_handler()
 
         socket, self._ftp_port = get_socket(ftp_port)
 
@@ -91,7 +104,7 @@ class SimpleFTPServer(FTPServer):
 
         # Create a new pyftpdlib server with the socket and handler we've
         # configured
-        FTPServer.__init__(self, socket, handler)
+        super().__init__(socket, handler)
 
     def stop(self):
         """

--- a/tests/test_pytest_localftpserver.py
+++ b/tests/test_pytest_localftpserver.py
@@ -116,14 +116,14 @@ def check_files_by_ftpclient(ftp_fixture, tmpdir, files_on_server, path_iterable
     else:
         base_path = ftp_fixture.server_home
     ftp = ftp_login(ftp_fixture, anon=anon, use_TLS=use_TLS)
-    download_dir = tmpdir.mkdir("download_rel_path")
+    download_dir = tmpdir.ensure("download_url", dir=True)
     for file_path in path_iterable:
         abs_file_path = os.path.abspath(os.path.join(base_path, file_path))
         assert os.path.isfile(abs_file_path)
         assert file_path in files_on_server
         dirs, filename = os.path.split(file_path)
         if dirs != "":
-            download_file = download_dir.mkdir(dirs).join(filename)
+            download_file = download_dir.ensure(dirs, dir=True).join(filename)
         else:
             download_file = download_dir.join(filename)
         with open(str(download_file), "wb") as f:
@@ -131,7 +131,7 @@ def check_files_by_ftpclient(ftp_fixture, tmpdir, files_on_server, path_iterable
         with open(str(download_file), "r") as f:
             assert f.read() == filename
     close_client(ftp)
-    download_dir.remove()
+    download_dir.remove(ignore_errors=True)
 
 
 def check_files_by_urls(tmpdir, base_url, url_iterable):
@@ -149,14 +149,14 @@ def check_files_by_urls(tmpdir, base_url, url_iterable):
         Contains urls to check
     """
     # checking files by url
-    download_dir = tmpdir.mkdir("download_url")
+    download_dir = tmpdir.ensure("download_url", dir=True)
     for url in url_iterable:
         _, filename = os.path.split(os.path.relpath(url, base_url))
         download_file = download_dir.join(filename)
         wget.download(url, str(download_file))
         with open(str(download_file), "r") as f:
             assert f.read() == filename
-    download_dir.remove()
+    download_dir.remove(ignore_errors=True)
 
 
 def check_get_file_contents(tmpdir, path_list, iterable_len, files_on_server,

--- a/tests/test_pytest_localftpserver.py
+++ b/tests/test_pytest_localftpserver.py
@@ -744,12 +744,12 @@ def test_multiple_servers():
     )
 
     ftp1 = FTP()
-    ftp1.connect("localhost", server1._server._ftp_port)
+    ftp1.connect("localhost", server1.server_port)
     ftp1.login("user1", "pass1")
     close_client(ftp1)
 
     ftp2 = FTP()
-    ftp2.connect("localhost", server2._server._ftp_port)
+    ftp2.connect("localhost", server2.server_port)
     ftp2.login("user2", "pass2")
     close_client(ftp2)
 

--- a/tests/test_pytest_localftpserver.py
+++ b/tests/test_pytest_localftpserver.py
@@ -728,3 +728,30 @@ def test_fail_due_to_closed_module_scope(ftpserver):
     ftp = FTP()
     with pytest.raises(Exception):
         ftp.connect("localhost", port=ftpserver.server_port)
+
+
+def test_multiple_servers():
+    """Interact with multiple servers at a time.
+
+    This shouldn't cause a 'ftplib.error_perm: 530 Authentication failed.' anymore.
+    See issue #137
+    """
+    server1 = PytestLocalFTPServer(
+        username="user1", password="pass1", ftp_home=None, ftp_port=34445
+    )
+    server2 = PytestLocalFTPServer(
+        username="user2", password="pass2", ftp_home=None, ftp_port=34446
+    )
+
+    ftp1 = FTP()
+    ftp1.connect("localhost", 34445)
+    ftp1.login("user1", "pass1")
+    close_client(ftp1)
+
+    ftp2 = FTP()
+    ftp2.connect("localhost", 34446)
+    ftp2.login("user2", "pass2")
+    close_client(ftp2)
+
+    server1.stop()
+    server2.stop()

--- a/tests/test_pytest_localftpserver.py
+++ b/tests/test_pytest_localftpserver.py
@@ -737,19 +737,19 @@ def test_multiple_servers():
     See issue #137
     """
     server1 = PytestLocalFTPServer(
-        username="user1", password="pass1", ftp_home=None, ftp_port=34445
+        username="user1", password="pass1", ftp_home=None, ftp_port=0
     )
     server2 = PytestLocalFTPServer(
-        username="user2", password="pass2", ftp_home=None, ftp_port=34446
+        username="user2", password="pass2", ftp_home=None, ftp_port=0
     )
 
     ftp1 = FTP()
-    ftp1.connect("localhost", 34445)
+    ftp1.connect("localhost", server1._server._ftp_port)
     ftp1.login("user1", "pass1")
     close_client(ftp1)
 
     ftp2 = FTP()
-    ftp2.connect("localhost", 34446)
+    ftp2.connect("localhost", server2._server._ftp_port)
     ftp2.login("user2", "pass2")
     close_client(ftp2)
 

--- a/tests/test_pytest_localftpserver_TLS.py
+++ b/tests/test_pytest_localftpserver_TLS.py
@@ -10,8 +10,9 @@ Tests for `pytest_localftpserver` module.
 
 import os
 
-from ftplib import error_perm, FTP
+from ftplib import error_perm, FTP_TLS
 import pytest
+from ssl import SSLContext, PROTOCOL_TLS
 
 
 from .test_pytest_localftpserver import (ftp_login,
@@ -165,15 +166,19 @@ def test_multiple_servers_TLS():
     server2 = PytestLocalFTPServer(
         username="user2", password="pass2", ftp_home=None, ftp_port=0, use_TLS=True
     )
+    ssl_context = SSLContext(PROTOCOL_TLS)
+    ssl_context.load_cert_chain(certfile=DEFAULT_CERTFILE)
 
-    ftp1 = FTP()
+    ftp1 = FTP_TLS(context=ssl_context)
     ftp1.connect("localhost", server1._server._ftp_port)
     ftp1.login("user1", "pass1")
+    ftp1.prot_p()
     close_client(ftp1)
 
-    ftp2 = FTP()
+    ftp2 = FTP_TLS(context=ssl_context)
     ftp2.connect("localhost", server2._server._ftp_port)
     ftp2.login("user2", "pass2")
+    ftp2.prot_p()
     close_client(ftp2)
 
     server1.stop()

--- a/tests/test_pytest_localftpserver_TLS.py
+++ b/tests/test_pytest_localftpserver_TLS.py
@@ -9,6 +9,7 @@ Tests for `pytest_localftpserver` module.
 """
 
 import os
+import sys
 
 from ftplib import error_perm, FTP_TLS
 import pytest
@@ -154,6 +155,10 @@ def test_wrong_cert_exception():
         SimpleFTPServer(use_TLS=True, certfile=wrong_cert)
 
 
+@pytest.mark.skipif(
+    sys.platform != 'linux',
+    reason="Currently thread based servers TLS cause Segfault"
+)
 def test_multiple_servers_TLS():
     """Interact with multiple TLS servers at a time.
 

--- a/tests/test_pytest_localftpserver_TLS.py
+++ b/tests/test_pytest_localftpserver_TLS.py
@@ -160,19 +160,19 @@ def test_multiple_servers_TLS():
     See issue #137
     """
     server1 = PytestLocalFTPServer(
-        username="user1", password="pass1", ftp_home=None, ftp_port=34445, use_TLS=True
+        username="user1", password="pass1", ftp_home=None, ftp_port=0, use_TLS=True
     )
     server2 = PytestLocalFTPServer(
-        username="user2", password="pass2", ftp_home=None, ftp_port=34446, use_TLS=True
+        username="user2", password="pass2", ftp_home=None, ftp_port=0, use_TLS=True
     )
 
     ftp1 = FTP()
-    ftp1.connect("localhost", 34445)
+    ftp1.connect("localhost", server1._server._ftp_port)
     ftp1.login("user1", "pass1")
     close_client(ftp1)
 
     ftp2 = FTP()
-    ftp2.connect("localhost", 34446)
+    ftp2.connect("localhost", server2._server._ftp_port)
     ftp2.login("user2", "pass2")
     close_client(ftp2)
 


### PR DESCRIPTION
As described in this comment (https://github.com/oz123/pytest-localftpserver/issues/137#issuecomment-867243935), the fact that the `authorizer` class attribute of `pyftpdlib.handlers.FTPHandler`/`pyftpdlib.handlers.TLS_FTPHandler` is overwritten, doesn't allow running multiple FTP servers with different credentials.

### Change list
- `SimpleFTPServer.handler` refers do a class definition inside of a closure, thus `authorizer` isn't overwritten when a new instance is created
- Added tests for running two different FTP server w and w/o TLS
- Made it easier to create an own fixture from `PytestLocalFTPServer` by extending the init parameters
- Added example of using two FTP fixtures to the docs


closes #137 