### PR TITLE
Add support for Python 3.10

### DIFF
--- a/.github/workflows/CI_CD_actions.yml
+++ b/.github/workflows/CI_CD_actions.yml
@@ -8,10 +8,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python 3.7
+      - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.9
       - name: Install dependencies
         run: |
           python -m pip install -U flake8
@@ -23,10 +23,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python 3.7
+      - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.9
       - name: Install dependencies
         run: |
           python -m pip install -U pip wheel
@@ -39,10 +39,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python 3.7
+      - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.9
       - name: Install dependencies
         run: |
           python -m pip install -U pip wheel
@@ -56,9 +56,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     #needs: [lint, docs]
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        python-version: [3.7]
+        python-version: ["3.6", "3.7", "3.8", "3.9"]
 
     steps:
       - uses: actions/checkout@v2
@@ -93,10 +94,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Python 3.7
+      - name: Set up Python
         uses: actions/setup-python@v2
         with:
-          python-version: 3.7
+          python-version: 3.9
       - name: Install dependencies
         run: |
           python -m pip install -U pip wheel
@@ -133,10 +134,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@master
-    - name: Set up Python 3.7
+    - name: Set up Python
       uses: actions/setup-python@v1
       with:
-        python-version: 3.7
+        python-version: 3.9
     - name: Install pypa/build
       run: |
         python -m pip install build --user

--- a/.github/workflows/CI_CD_actions.yml
+++ b/.github/workflows/CI_CD_actions.yml
@@ -59,7 +59,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        python-version: ["3.6", "3.7", "3.8", "3.9"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10-dev"]
 
     steps:
       - uses: actions/checkout@v2

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -102,7 +102,7 @@ Before you submit a pull request, check that it meets these guidelines:
 2. If the pull request adds functionality, the docs should be updated. Put
    your new functionality into a function with a docstring, and add the
    feature to the list in README.rst.
-3. The pull request should work for Python 3.5, 3.6 and 3.7 . Check
+3. The pull request should work for Python 3.6+. Check
    https://github.com/oz123/pytest-localftpserver/actions?query=workflow%3ATests
    and make sure that the tests pass for all supported Python versions.
 

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -111,7 +111,7 @@ Tips
 
 To run a subset of tests::
 
-    $ py.test tests/test_pytest_localftpserver.py::<test_name>
+    $ pytest tests/test_pytest_localftpserver.py::<test_name>
 
 
 Deploying

--- a/README.rst
+++ b/README.rst
@@ -107,7 +107,7 @@ Sample config for Tox::
         FTP_HOME_TLS = /home/ftp_test_TLS
         FTP_CERTFILE = {toxinidir}/tests/test_keycert.pem
     commands =
-        py.test tests
+        pytest tests
 
 Credits
 -------

--- a/README.rst
+++ b/README.rst
@@ -93,7 +93,7 @@ Sample config for Tox::
 
     $ cat tox.ini
     [tox]
-    envlist = py{35,36,37}
+    envlist = py{36,37,38,39,310}
 
     [testenv]
     setenv =

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 #
 # pytest_localftpserver documentation build configuration file, created by
 # sphinx-quickstart on Tue Jul  9 22:26:36 2013.
@@ -66,8 +65,8 @@ source_suffix = '.rst'
 master_doc = 'index'
 
 # General information about the project.
-project = u'PyTest local FTP Server'
-copyright = u"2016, Oz Tiram"
+project = 'PyTest local FTP Server'
+copyright = "2016, Oz Tiram"
 
 # The version info for the project you're documenting, acts as replacement
 # for |version| and |release|, also used in various other places throughout
@@ -229,8 +228,8 @@ latex_elements = {
 # [howto/manual]).
 latex_documents = [
     ('index', 'pytest_localftpserver.tex',
-     u'PyTest local FTP Server Documentation',
-     u'Oz Tiram', 'manual'),
+     'PyTest local FTP Server Documentation',
+     'Oz Tiram', 'manual'),
 ]
 
 # The name of an image file (relative to this directory) to place at
@@ -260,8 +259,8 @@ latex_documents = [
 # (source start file, name, description, authors, manual section).
 man_pages = [
     ('index', 'pytest_localftpserver',
-     u'PyTest local FTP Server Documentation',
-     [u'Oz Tiram'], 1)
+     'PyTest local FTP Server Documentation',
+     ['Oz Tiram'], 1)
 ]
 
 # If true, show URL addresses after external links.
@@ -275,8 +274,8 @@ man_pages = [
 #  dir menu entry, description, category)
 texinfo_documents = [
     ('index', 'pytest_localftpserver',
-     u'PyTest local FTP Server Documentation',
-     u'Oz Tiram',
+     'PyTest local FTP Server Documentation',
+     'Oz Tiram',
      'pytest_localftpserver',
      'One line description of project.',
      'Miscellaneous'),

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -56,31 +56,21 @@ An other common use case would be retrieving a file from a FTP-server.
 Login with the TLS server
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Since Python 2 and 3, as well as different versions of python 3 differ in their implementation of the
-client ``FTP_TLS`` and/or ssl protocol/context, we provide you with an example which works on
-python 2.7, 3.4, 3.5 3.6 and 3.7
-(note that, this example utilizes methods of the the high-level interface, which are  explained in
-:ref:`get_login_data` and :ref:`get_file_contents`).
+Tthis example utilizes methods of the the high-level interface, which are  explained in
+:ref:`get_login_data` and :ref:`get_file_contents`.
 
 The below example test logs into the TLS ftpserver, creates the file ``testfile.txt``, with content 'test text' and
 checks if it was written properly.
 
 .. code-block:: python
 
-    import sys
     from ftplib import FTP_TLS
 
-    if sys.version_info[0] == 3:
-        PYTHON3 = True
-    else:
-        PYTHON3 = False
-
-    if PYTHON3:
-        from ssl import SSLContext
-        try:
-            from ssl import PROTOCOL_TLS
-        except Exception:
-            from ssl import PROTOCOL_SSLv23 as PROTOCOL_TLS
+    from ssl import SSLContext
+    try:
+        from ssl import PROTOCOL_TLS
+    except Exception:
+        from ssl import PROTOCOL_SSLv23 as PROTOCOL_TLS
 
 
     def test_TLS_login(ftpserver_TLS):
@@ -303,7 +293,7 @@ You can either set environment variables on a system level or use tools such as
            (``FTP_PORT``/ ``FTP_PORT_TLS``).
            This is due to the server still listening on that port, which prevents it from adding another listener
            on that port. When using pythons buildin ``ftplib``, you should use the
-           `quit method <https://docs.python.org/3.7/library/ftplib.html#ftplib.FTP.quit>`_
+           `quit method <https://docs.python.org/3/library/ftplib.html#ftplib.FTP.quit>`_
            to terminate the connection, since it's the `'the “polite” way to close a connection'` and lets the
            server know that the client isn't just experiencing connection problems, but won't come back.
 
@@ -334,7 +324,7 @@ Configuration with Tox
 
 The configuration of tox is done in the ``tox.ini`` file.
 The following example configuration will run the tests in the folder ``tests`` on
-python 3.5, 3.6 and 3.7 and use the username ``benz``, the password ``erni1``,
+python 3.6+ and use the username ``benz``, the password ``erni1``,
 the tempfolder of each virtual environment the tests are run in (``{envtmpdir}``) and
 the ftp port ``31175``.
 For the encrypted version of the fixture it uses port ``31176`` and the certificate
@@ -342,7 +332,7 @@ For the encrypted version of the fixture it uses port ``31176`` and the certific
 
     $ cat tox.ini
     [tox]
-    envlist = py{35,36,37}
+    envlist = py{36,37,38,39,310}
 
     [testenv]
     setenv =

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -346,5 +346,5 @@ For the encrypted version of the fixture it uses port ``31176`` and the certific
         FTP_HOME_TLS = /home/ftp_test_TLS
         FTP_CERTFILE = {toxinidir}/tests/test_keycert.pem
     commands =
-        py.test tests
+        pytest tests
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -56,7 +56,7 @@ An other common use case would be retrieving a file from a FTP-server.
 Login with the TLS server
 ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Tthis example utilizes methods of the the high-level interface, which are  explained in
+This example utilizes methods of the the high-level interface, which are  explained in
 :ref:`get_login_data` and :ref:`get_file_contents`.
 
 The below example test logs into the TLS ftpserver, creates the file ``testfile.txt``, with content 'test text' and

--- a/pytest_localftpserver/__init__.py
+++ b/pytest_localftpserver/__init__.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 __author__ = """Oz Tiram"""
 __email__ = 'oz.tiram@gmail.com'
 __version__ = '1.0.1'

--- a/pytest_localftpserver/helper_functions.py
+++ b/pytest_localftpserver/helper_functions.py
@@ -1,6 +1,3 @@
-# -*- coding: utf-8 -*-
-from __future__ import print_function, absolute_import
-
 from copy import deepcopy
 import logging
 import os
@@ -173,7 +170,7 @@ def arg_validator_excepthook(exc_type, exc_value, exc_traceback):
     # since the excepthook will be caught by pytest there is no reason to
     # run it trought coverage
     print_tb(exc_traceback, limit=1, file=sys.stderr)  # pragma: no cover
-    print("{}: {}".format(exc_type.__name__, exc_value), file=sys.stderr)  # pragma: no cover
+    print(f"{exc_type.__name__}: {exc_value}", file=sys.stderr)  # pragma: no cover
 
 
 def arg_validator(func_locals, valid_var_dict, valid_var_overwrite=None,
@@ -293,7 +290,7 @@ def arg_validator(func_locals, valid_var_dict, valid_var_overwrite=None,
                         msg_dict["type_string"] = "``{}``" \
                                                   "".format(valid_types[0].__name__)
                     else:
-                        valid_type_list = ["``{}``".format(valid_type.__name__)
+                        valid_type_list = [f"``{valid_type.__name__}``"
                                            for valid_type in valid_types[:-1]]
                         base_str = ", ".join(valid_type_list)
                         msg_dict["type_string"] = "{} or ``{}``" \

--- a/pytest_localftpserver/plugin.py
+++ b/pytest_localftpserver/plugin.py
@@ -1,6 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
-from __future__ import print_function, absolute_import
 
 import pytest
 

--- a/pytest_localftpserver/servers.py
+++ b/pytest_localftpserver/servers.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-
 from collections.abc import Iterable
 from functools import wraps
 import multiprocessing
@@ -125,7 +123,7 @@ class SimpleFTPServer(FTPServer):
                 os.makedirs(self._ftp_home)
 
 
-class FunctionalityWrapper(object):
+class FunctionalityWrapper:
     """
     Baseclass which holds the functionality of ftpserver.
     The derived classes are ThreadFTPServer and ProcessFTPServer, which
@@ -286,7 +284,7 @@ class FunctionalityWrapper(object):
                     heading = f.__name__.upper()
                     msg_line = []
                     for key in sorted(func_locals):
-                        msg_line.append("'{}': {}".format(key, func_locals[key]))
+                        msg_line.append(f"'{key}': {func_locals[key]}")
                     msg = "\n".join(msg_line)
                     pretty_logger(heading, "FUNC_LOCALS\n"+msg+"\n\n")
                 try:
@@ -1085,7 +1083,7 @@ class ThreadFTPServer(FunctionalityWrapper):
     To learn about the functionality check out BaseMPFTPServer.
     """
     def __init__(self, use_TLS=False):
-        super(ThreadFTPServer, self).__init__(use_TLS=use_TLS)
+        super().__init__(use_TLS=use_TLS)
         # The server needs to run in a separate thread or it will block all tests
         self.thread = threading.Thread(target=self._server.serve_forever)
         # This is a must in order to clear used sockets
@@ -1093,7 +1091,7 @@ class ThreadFTPServer(FunctionalityWrapper):
         self.thread.start()
 
     def stop(self):
-        super(ThreadFTPServer, self).stop()
+        super().stop()
         self.thread.join()
 
 
@@ -1104,7 +1102,7 @@ class ProcessFTPServer(FunctionalityWrapper):
     To learn about the functionality check out BaseMPFTPServer.
     """
     def __init__(self, use_TLS=False):
-        super(ProcessFTPServer, self).__init__(use_TLS=use_TLS)
+        super().__init__(use_TLS=use_TLS)
         # The server needs to run in a separate process or it will block all tests
         self.process = multiprocessing.Process(target=self._server.serve_forever)
         # This is a must in order to clear used sockets
@@ -1112,7 +1110,7 @@ class ProcessFTPServer(FunctionalityWrapper):
         self.process.start()
 
     def stop(self):
-        super(ProcessFTPServer, self).stop()
+        super().stop()
         self.process.terminate()
 
 

--- a/pytest_localftpserver/servers.py
+++ b/pytest_localftpserver/servers.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-import collections
+from collections.abc import Iterable
 from functools import wraps
 import multiprocessing
 import os
@@ -641,12 +641,12 @@ class FunctionalityWrapper(object):
             "rel_file_paths":
                 {'valid_types': [type(None),
                                  str,
-                                 collections.Iterable]}
+                                 Iterable]}
         },
         strict_type_check=False)
     # if you use dev_mode=True here you will get a warning that `rel_file_paths`, isn't in
     # `valid_var_list` this is on purpose, since `rel_file_paths` gets checked with
-    # `strict_type_check=False` to be able to check `collections.Iterable`
+    # `strict_type_check=False` to be able to check `collections.abc.Iterable`
     @_option_validator(dev_mode=False)
     def get_file_contents(self, rel_file_paths=None, style="rel_path",
                           anon=False, read_mode="r"):
@@ -742,7 +742,7 @@ class FunctionalityWrapper(object):
         base_path = self.get_local_base_path(anon=anon)
         if not rel_file_paths:
             rel_file_paths = self.get_file_paths(style=style, anon=anon)
-        if isinstance(rel_file_paths, str) or not isinstance(rel_file_paths, collections.Iterable):
+        if isinstance(rel_file_paths, str) or not isinstance(rel_file_paths, Iterable):
             rel_file_paths = [rel_file_paths]
         for rel_file_path in rel_file_paths:
             if "ftp://" in rel_file_path:
@@ -904,7 +904,7 @@ class FunctionalityWrapper(object):
         """
 
         is_str_or_dict = isinstance(files_on_local, (str, dict))
-        if is_str_or_dict or not isinstance(files_on_local, collections.Iterable):
+        if is_str_or_dict or not isinstance(files_on_local, Iterable):
             files_on_local = [files_on_local]
 
         base_path = self.get_local_base_path(anon=anon)

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setup(
     license="MIT license",
     zip_safe=False,
     keywords='pytest_localftpserver pytest fixture ftp server local',
+    python_requires='>=3.6',
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,8 @@ setup(
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
+        'Programming Language :: Python :: 3 :: Only',
         "Framework :: Pytest",
         'Topic :: Software Development :: Testing',
         "Topic :: Software Development :: Testing :: Mocking"

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 from setuptools import setup
 from setuptools import find_packages

--- a/tests/test_helper_functions.py
+++ b/tests/test_helper_functions.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 from collections.abc import Iterable
 import logging
@@ -115,8 +114,7 @@ def test_arg_validator():
 
     # test type validation not strict
     def test_generator_func():
-        for item in [1, 2]:
-            yield item
+        yield from [1, 2]
 
     test_generator = test_generator_func()
 

--- a/tests/test_helper_functions.py
+++ b/tests/test_helper_functions.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from collections import Iterable
+from collections.abc import Iterable
 import logging
 import os
 import socket

--- a/tests/test_pytest_localftpserver.py
+++ b/tests/test_pytest_localftpserver.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 """
 test_pytest_localftpserver
@@ -128,7 +127,7 @@ def check_files_by_ftpclient(ftp_fixture, tmpdir, files_on_server, path_iterable
             download_file = download_dir.join(filename)
         with open(str(download_file), "wb") as f:
             ftp.retrbinary("RETR "+file_path, f.write)
-        with open(str(download_file), "r") as f:
+        with open(str(download_file)) as f:
             assert f.read() == filename
     close_client(ftp)
     download_dir.remove()
@@ -154,7 +153,7 @@ def check_files_by_urls(tmpdir, base_url, url_iterable):
         _, filename = os.path.split(os.path.relpath(url, base_url))
         download_file = download_dir.join(filename)
         wget.download(url, str(download_file))
-        with open(str(download_file), "r") as f:
+        with open(str(download_file)) as f:
             assert f.read() == filename
     download_dir.remove()
 
@@ -345,7 +344,7 @@ def test_file_upload_user(ftpserver, tmpdir):
     assert os.path.isdir(os.path.join(ftpserver.server_home, "FOO"))
     abs_file_path_server = os.path.join(ftpserver.server_home, "FOO", filename)
     assert os.path.isfile(abs_file_path_server)
-    with open(abs_file_path_server, "r") as f:
+    with open(abs_file_path_server) as f:
         assert f.read() == "test"
 
 

--- a/tests/test_pytest_localftpserver_TLS.py
+++ b/tests/test_pytest_localftpserver_TLS.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 """
 test_pytest_localftpserver
@@ -64,7 +63,7 @@ def test_file_upload_user(ftpserver_TLS, tmpdir):
     assert os.path.isdir(os.path.join(ftpserver_TLS.server_home, "FOO"))
     abs_file_path_server = os.path.join(ftpserver_TLS.server_home, "FOO", filename)
     assert os.path.isfile(abs_file_path_server)
-    with open(abs_file_path_server, "r") as f:
+    with open(abs_file_path_server) as f:
         assert f.read() == "test"
 
 

--- a/tests/test_pytest_localftpserver_with_env_var.py
+++ b/tests/test_pytest_localftpserver_with_env_var.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 from ftplib import FTP
 import os
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,11 @@
 [tox]
 minversion = 3.4.0
-envlist = py{37,38,39}, custom_config, flake8, docs, docs-links
+envlist = py{36,37,38,39}, custom_config, flake8, docs, docs-links
 
 
 [gh-actions]
 python =
+    3.6: py36
     3.7: py37
     3.8: py38
     3.9: py39

--- a/tox.ini
+++ b/tox.ini
@@ -47,7 +47,7 @@ commands_pre =
     {envpython} -m pip install -U -q -r {toxinidir}/requirements_dev.txt
 commands =
     {env:COMMAND:coverage} erase
-    {env:COMMAND:coverage} run --append -m py.test --basetemp={envtmpdir} tests/test_pytest_localftpserver_with_env_var.py
+    {env:COMMAND:coverage} run --append -m pytest --basetemp={envtmpdir} tests/test_pytest_localftpserver_with_env_var.py
     {env:COMMAND:coverage} report --show-missing
 
 
@@ -59,5 +59,5 @@ commands_pre =
     {envpython} -m pip install -U -q -r {toxinidir}/requirements_dev.txt
 commands =
     {env:COMMAND:coverage} erase
-    {env:COMMAND:coverage} run --append -m py.test --basetemp={envtmpdir} tests/test_pytest_localftpserver.py tests/test_helper_functions.py tests/test_pytest_localftpserver_TLS.py
+    {env:COMMAND:coverage} run --append -m pytest --basetemp={envtmpdir} tests/test_pytest_localftpserver.py tests/test_helper_functions.py tests/test_pytest_localftpserver_TLS.py
     {env:COMMAND:coverage} report --show-missing

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 3.4.0
-envlist = py{36,37,38,39}, custom_config, flake8, docs, docs-links
+envlist = py{36,37,38,39,310}, custom_config, flake8, docs, docs-links
 
 
 [gh-actions]
@@ -9,6 +9,7 @@ python =
     3.7: py37
     3.8: py38
     3.9: py39
+    3.10: py310
 
 
 [flake8]


### PR DESCRIPTION
The main point of this PR is to add support for Python 3.10.

It may be easier to review this PR commit by commit, and please let me know if you'd prefer smaller PRs.

---

First, update the CI testing to test all supported Python versions: 3.6-3.9.

Next, add support for Python 3.10. This requires code change: `collections.Iterable` has been removed from 3.10 and has been at `collections.abc.Iterable` since 3.3.

Next, upgrade to more modern Python syntax using https://github.com/asottile/pyupgrade

Next, update docs to reflect 3.6 is the minimum supported.

Finally, drop the dot in `py.test`: https://twitter.com/pytestdotorg/status/753767547866972160

---

It would be great to get a release out for this sooner rather than later, as other libraries which depend on pytest-localftpserver cannot test/support Python 3.10 due to the `collections.Iterable` change ([for example](https://github.com/hugovk/pooch/runs/3412944323?check_suite_focus=true)).

Thank you!