### PR TITLE
Use `PROTOCOL_TLS_CLIENT` in favour of `PROTOCOL_TLS`

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -68,14 +68,16 @@ checks if it was written properly.
 
     from ssl import SSLContext
     try:
-        from ssl import PROTOCOL_TLS
+        from ssl import PROTOCOL_TLS_CLIENT, TLSVersion
     except Exception:
         from ssl import PROTOCOL_SSLv23 as PROTOCOL_TLS
 
 
     def test_TLS_login(ftpserver_TLS):
         if PYTHON3:
-            ssl_context = SSLContext(PROTOCOL_TLS)
+            ssl_context = SSLContext(PROTOCOL_TLS_CLIENT)
+            ssl_context.minimum_version = TLSVersion.TLSv1_2
+            ssl_context.maximum_version = TLSVersion.TLSv1_3
             ssl_context.load_cert_chain(certfile=DEFAULT_CERTFILE)
             ftp = FTP_TLS(context=ssl_context)
         else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,8 @@ classifiers = [
 dependencies = [
   'pyftpdlib>=1.2.0',
   'PyOpenSSL',
-  'pytest'
+  'pytest',
+  'wget'
 ]
 
 [tool.setuptools]

--- a/pytest_localftpserver/helper_functions.py
+++ b/pytest_localftpserver/helper_functions.py
@@ -7,7 +7,7 @@ from traceback import print_tb
 import warnings
 
 from ssl import SSLContext, SSLError
-from ssl import PROTOCOL_TLS
+from ssl import PROTOCOL_TLS_CLIENT, TLSVersion
 
 DEFAULT_CERTFILE = os.path.join(os.path.dirname(__file__),
                                 "default_keycert.pem")
@@ -81,7 +81,9 @@ def validate_cert_file(cert_file):
     """
     cert_file = os.path.abspath(cert_file)
     try:
-        context = SSLContext(PROTOCOL_TLS)
+        context = SSLContext(PROTOCOL_TLS_CLIENT)
+        context.minimum_version = TLSVersion.TLSv1_2
+        context.maximum_version = TLSVersion.TLSv1_3
         context.load_cert_chain(cert_file)
     except SSLError as e:
         raise InvalidCertificateError("The certificate {}, you tried to use is not valid. "

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -3,8 +3,8 @@ wheel>=0.30.0
 
 # install requirements
 pyftpdlib==1.5.8
-PyOpenSSL==23.2.0
-pytest==7.4.4
+pyOpenSSL==24.1.0
+pytest==8.2.0
 
 # documentation
 Sphinx>=1.8
@@ -13,6 +13,6 @@ sphinx-rtd-theme>=0.5.0
 
 # testing
 flake8>=2.6.0
-tox==4.11.4
+tox==4.15.0
 coverage>=4.3.0
 wget>=3.2

--- a/tests/test_pytest_localftpserver.py
+++ b/tests/test_pytest_localftpserver.py
@@ -19,7 +19,7 @@ from pytest_localftpserver.servers import USE_PROCESS
 from pytest_localftpserver.helper_functions import DEFAULT_CERTFILE
 
 
-from ssl import SSLContext, PROTOCOL_TLS
+from ssl import SSLContext, PROTOCOL_TLS_CLIENT, TLSVersion
 
 # HELPER FUNCTIONS
 
@@ -54,7 +54,9 @@ def ftp_login(ftp_fixture, anon=False, use_TLS=False):
 
     """
     if use_TLS:
-        ssl_context = SSLContext(PROTOCOL_TLS)
+        ssl_context = SSLContext(PROTOCOL_TLS_CLIENT)
+        ssl_context.minimum_version = TLSVersion.TLSv1_2
+        ssl_context.maximum_version = TLSVersion.TLSv1_3
         ssl_context.load_cert_chain(certfile=DEFAULT_CERTFILE)
         ftp = FTP_TLS(context=ssl_context)
     else:


### PR DESCRIPTION
`PROTOCOL_TLS` was deprecated in `ssl` v3.10.
Fixes #303 