### PR TITLE
Replace use of wget in tests with plain urllib.request

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,6 @@ dependencies = [
   'pyftpdlib>=1.2.0',
   'PyOpenSSL',
   'pytest',
-  'wget'
 ]
 
 [tool.setuptools]

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -16,4 +16,3 @@ sphinx-rtd-theme>=0.5.0
 flake8>=2.6.0
 tox==4.15.0
 coverage>=4.3.0
-wget>=3.2

--- a/tests/test_pytest_localftpserver.py
+++ b/tests/test_pytest_localftpserver.py
@@ -10,9 +10,9 @@ Tests for `pytest_localftpserver` module.
 from ftplib import FTP, FTP_TLS, error_perm
 import logging
 import os
+import urllib.request
 
 import pytest
-import wget
 
 from pytest_localftpserver.plugin import PytestLocalFTPServer
 from pytest_localftpserver.servers import USE_PROCESS
@@ -158,14 +158,10 @@ def check_files_by_urls(tmpdir, base_url, url_iterable):
         Contains urls to check
     """
     # checking files by url
-    download_dir = tmpdir.mkdir("download_url")
     for url in url_iterable:
         _, filename = os.path.split(os.path.relpath(url, base_url))
-        download_file = download_dir.join(filename)
-        wget.download(url, str(download_file))
-        with open(str(download_file)) as f:
-            assert f.read() == filename
-    download_dir.remove()
+        with urllib.request.urlopen(url) as response:
+            assert response.read() == filename.encode()
 
 
 def check_get_file_contents(


### PR DESCRIPTION
The wget package is no longer maintained, with last release in 2015 and the homepage no longer accessible.  Replace it with stdlib urllib.request, that also makes the test much simpler, and removes the necessity of writing into the filesystem.