### PR TITLE
feat: add macOS support

### DIFF
--- a/pytest_localftpserver/servers.py
+++ b/pytest_localftpserver/servers.py
@@ -33,7 +33,7 @@ class WrongFixtureError(Exception):
     pass
 
 
-class SimpleFTPServer(FTPServer):
+class SimpleFTPServer:
     """
     Starts a simple FTP server.
 
@@ -97,18 +97,15 @@ class SimpleFTPServer(FTPServer):
             handler = FTPHandler
         handler.authorizer = authorizer
 
-        # Create an independent IOLoop instance for the current thread to use.
-        # This prevents multiple server threads from competing for the global socket map.
-        self.ioloop = IOLoop()
-
-        # Create a new pyftpdlib server with the socket and handler we've
-        # configured
-        FTPServer.__init__(self, self._socket, handler, ioloop=self.ioloop)
+        # Create a new pyftpdlib server with the socket and handler we've configured
+        # Create an independent IOLoop instance for the current thread to use,
+        # which prevents multiple server threads from competing for the global socket map.
+        server = FTPServer(self._socket, handler, ioloop=IOLoop())
 
         while not self.shutdown_event.is_set():
-            self.serve_forever(timeout=1, blocking=False, handle_exit=False)
+            server.serve_forever(timeout=1, blocking=False, handle_exit=False)
 
-        self.close_all()
+        server.close_all()
 
     def stop(self):
         """

--- a/tests/test_pytest_localftpserver.py
+++ b/tests/test_pytest_localftpserver.py
@@ -16,7 +16,6 @@ import pytest
 import ssl
 
 from pytest_localftpserver.plugin import PytestLocalFTPServer
-from pytest_localftpserver.servers import USE_PROCESS
 from pytest_localftpserver.helper_functions import DEFAULT_CERTFILE
 
 
@@ -229,12 +228,8 @@ def run_ftp_stopped_test(ftpserver_fixture):
     """
     ftpserver_fixture.stop()
     ftp = FTP()
-    if USE_PROCESS:
-        with pytest.raises((ConnectionRefusedError, ConnectionResetError)):
-            ftp.connect("localhost", port=ftpserver_fixture.server_port)
-    else:
-        with pytest.raises(OSError):
-            ftp.connect("localhost", port=ftpserver_fixture.server_port)
+    with pytest.raises((ConnectionRefusedError, ConnectionResetError)):
+        ftp.connect("localhost", port=ftpserver_fixture.server_port)
 
 
 # ACTUAL TESTS

--- a/tests/test_pytest_localftpserver.py
+++ b/tests/test_pytest_localftpserver.py
@@ -228,7 +228,7 @@ def run_ftp_stopped_test(ftpserver_fixture):
     """
     ftpserver_fixture.stop()
     ftp = FTP()
-    with pytest.raises((ConnectionRefusedError, ConnectionResetError)):
+    with pytest.raises(OSError):
         ftp.connect("localhost", port=ftpserver_fixture.server_port)
 
 

--- a/tests/test_pytest_localftpserver_TLS.py
+++ b/tests/test_pytest_localftpserver_TLS.py
@@ -158,4 +158,4 @@ def test_wrong_cert_exception():
     wrong_cert = os.path.abspath(os.path.join(os.path.dirname(__file__),
                                               "not_a_valid_cert.pem"))
     with pytest.raises(InvalidCertificateError):
-        SimpleFTPServer(use_TLS=True, certfile=wrong_cert)
+        SimpleFTPServer(use_TLS=True, certfile=wrong_cert).run()


### PR DESCRIPTION
Resolves #151.

According to https://stackoverflow.com/q/45438323 and https://github.com/giampaolo/pyftpdlib/issues/526#issuecomment-626030556, the solution is to start the I/O loop in the child process rather than in the main process. In other words, we should initialize the FTPServer in the child process instead of in the main process.