### PR TITLE
chore(deps): unpin `cryptography`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,8 +33,7 @@ classifiers = [
 dependencies = [
   'pyftpdlib>=1.2.0',
   'PyOpenSSL',
-  'pytest',
-  'cryptography>=43'
+  'pytest'
 ]
 
 [tool.setuptools]


### PR DESCRIPTION
`cryptography` is only a transitive dependency and doesn’t need to be managed directly by us.

Under default conditions, an appropriate version will be installed automatically.

Pinning it instead unnecessarily increases dependency complexity and raises confusion as to why it’s being explicitly fixed.