### PR TITLE
Add Python 3.10 and Python 3.14 to the test matrix

### DIFF
--- a/.github/workflows/CI_CD_actions.yml
+++ b/.github/workflows/CI_CD_actions.yml
@@ -59,7 +59,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        python-version: ["3.11", "3.12", "3.13"]
+        python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
 
     steps:
       - uses: actions/checkout@v2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
   'Programming Language :: Python :: 3.11',
   'Programming Language :: Python :: 3.12',
   'Programming Language :: Python :: 3.13',
+  'Programming Language :: Python :: 3.14',
   'Programming Language :: Python :: 3 :: Only',
   'Framework :: Pytest',
   'Topic :: Software Development :: Testing',

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -2,14 +2,9 @@ bump2version>=0.5.10
 wheel>=0.30.0
 
 # install requirements
-
-
 pyftpdlib>=2.0.0
 pyOpenSSL>=24.1.0
 pytest>=9.0.0
-
-
-
 
 # documentation
 Sphinx>=1.8

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 3.4.0
-envlist = py{310,311,312,313}, custom_config, flake8, docs, docs-links
+envlist = py{310,311,312,313,314}, custom_config, flake8, docs, docs-links
 
 
 [gh-actions]
@@ -9,6 +9,7 @@ python =
     3.11: py311
     3.12: py312
     3.13: py313
+    3.14: py314
 
 
 [flake8]


### PR DESCRIPTION
Python 3.10 and Python 3.14 are both supported versions, and we should test them in CI.

If test duration is a concern, we should at least test the minimum, maximum, and an intermediate Python version, i.e. Python 3.10, 3.12, and 3.14.